### PR TITLE
Switch to Puppet 4

### DIFF
--- a/scripts/puppet.sh
+++ b/scripts/puppet.sh
@@ -2,16 +2,14 @@ set -e
 
 # Prepare puppetlabs repo
 CODENAME=`lsb_release -cs`
-if [ "$CODENAME" = "jessie" ]; then
-    CODENAME=testing
-fi
-wget http://apt.puppetlabs.com/puppetlabs-release-"$CODENAME".deb
-dpkg -i puppetlabs-release-"$CODENAME".deb
+
+wget http://apt.puppetlabs.com/puppetlabs-release-pc1-"$CODENAME".deb
+dpkg -i puppetlabs-release-pc1-"$CODENAME".deb
 apt-get update
 
 # Install puppet/facter
-apt-get install -y puppet facter
-rm -f puppetlabs-release-"$CODENAME".deb
+apt-get install -y puppet-agent
+rm -f puppetlabs-release-pc1-"$CODENAME".deb
 
 # Disable Puppet agent on systemd
 # PuppetLabs has the service disabled per default


### PR DESCRIPTION
Puppetlabs now have packages available for PC1 (Puppet 4) with all the
codenames of the debian distros available.

The "puppet" package is no longer included - it has been broken up into
"puppet-master" and "puppet-agent", both of which include facter
automatically.
